### PR TITLE
Make OpInput (input operator) read 1 line...

### DIFF
--- a/main.go
+++ b/main.go
@@ -1080,8 +1080,8 @@ func OpPrintV() {
 }
 
 func OpInput() {
-	var input string
-	fmt.Scanln(&input)
+	inputReader := bufio.NewReader(os.Stdin)
+	input, _ := inputReader.ReadString('\n')
 	inpExpr := Expr{}
 	inpExpr.Type = ExprStr
 	inpExpr.AsStr = input


### PR DESCRIPTION
... instead of only 1 word

If you still want an operator that reads 1 word at a time, still consider adding this, perhaps renamed as `readLine`?